### PR TITLE
Some proto3 improvements

### DIFF
--- a/Protocol Buffers.tmbundle/Syntaxes/Protocol Buffer.tmLanguage
+++ b/Protocol Buffers.tmbundle/Syntaxes/Protocol Buffer.tmLanguage
@@ -364,6 +364,10 @@
 					<key>include</key>
 					<string>#user_defined_message_field</string>
 				</dict>
+				<dict>
+					<key>include</key>
+					<string>#reserved_field</string>
+				</dict>
 			</array>
 		</dict>
 		<key>anywhere_option</key>
@@ -542,6 +546,24 @@
 			</dict>
 			<key>match</key>
 			<string>(repeated)?\s+?(((s|u)?int|s?fixed)(32|64)|string|bytes|bool)\s+(\S+)\s*=\s*(\d+)</string>
+		</dict>
+		<key>reserved_field</key>
+		<dict>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.control.occurrences.protobuf</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>constant.numeric.field-tag.protobuf</string>
+				</dict>
+			</dict>
+			<key>match</key>
+			<string>(reserved)\s+(\d+)</string>
 		</dict>
 		<key>rpc_primitive_attribute</key>
 		<dict>

--- a/Protocol Buffers.tmbundle/Syntaxes/Protocol Buffer.tmLanguage
+++ b/Protocol Buffers.tmbundle/Syntaxes/Protocol Buffer.tmLanguage
@@ -315,7 +315,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>\b(package)\s+([A-Za-z0-9.]+)\s*;</string>
+			<string>\b(package)\s+([A-Za-z0-9._]+)\s*;</string>
 			<key>name</key>
 			<string>meta.package.protobuf</string>
 		</dict>

--- a/Protocol Buffers.tmbundle/Syntaxes/Protocol Buffer.tmLanguage
+++ b/Protocol Buffers.tmbundle/Syntaxes/Protocol Buffer.tmLanguage
@@ -459,7 +459,7 @@
 		<key>group_field</key>
 		<dict>
 			<key>begin</key>
-			<string>(required|optional|repeated)\s+(group)\s+([A-Za-z0-9_]+)\s*=\s*(\d+)\s*{</string>
+			<string>(repeated)?\s+?(group)\s+([A-Za-z0-9_]+)\s*=\s*(\d+)\s*{</string>
 			<key>captures</key>
 			<dict>
 				<key>1</key>
@@ -541,7 +541,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>(required|optional|repeated)\s+(((s|u)?int|s?fixed)(32|64)|string|bytes|bool)\s+(\S+)\s*=\s*(\d+)</string>
+			<string>(repeated)?\s+?(((s|u)?int|s?fixed)(32|64)|string|bytes|bool)\s+(\S+)\s*=\s*(\d+)</string>
 		</dict>
 		<key>rpc_primitive_attribute</key>
 		<dict>
@@ -667,7 +667,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>(required|optional|repeated)\s+([A-Za-z.]*)\s+(\S+)\s*=\s*(\d+)</string>
+			<string>(repeated)?\s+?([A-Za-z._]*)\s+(\S+)\s*=\s*(\d+)</string>
 		</dict>
 	</dict>
 	<key>scopeName</key>

--- a/Protocol Buffers.tmbundle/Syntaxes/Protocol Buffer.tmLanguage
+++ b/Protocol Buffers.tmbundle/Syntaxes/Protocol Buffer.tmLanguage
@@ -34,6 +34,25 @@
 			<string>meta.import.declaration.protobuf</string>
 		</dict>
 		<dict>
+			<key>captures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>keyword.other.syntax.protobuf</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>string.quoted.double.syntax.protobuf</string>
+				</dict>
+			</dict>
+			<key>match</key>
+			<string>(syntax)\s*=\s*(".*")</string>
+			<key>name</key>
+			<string>meta.syntax.declaration.protobuf</string>
+		</dict>
+		<dict>
 			<key>begin</key>
 			<string>\b(message)\s+([A-Za-z0-9_]+)\s*\{</string>
 			<key>captures</key>

--- a/Protocol Buffers.tmbundle/Syntaxes/Protocol Buffer.tmLanguage
+++ b/Protocol Buffers.tmbundle/Syntaxes/Protocol Buffer.tmLanguage
@@ -231,7 +231,7 @@
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>\b(rpc)\s+([A-Za-z0-9_]+)\s+\(([A-Za-z0-9_]+)\)\s*(returns)\s*\(([A-Za-z0-9_]+)\)\s*;</string>
+					<string>\b(rpc)\s+([A-Za-z0-9_]+)\s+\(([A-Za-z0-9_.]+)\)\s*(returns)\s*\(([A-Za-z0-9_.]+)\)\s*;</string>
 					<key>name</key>
 					<string>meta.individual-rpc-call.protobuf</string>
 				</dict>

--- a/Protocol Buffers.tmbundle/Syntaxes/Protocol Buffer.tmLanguage
+++ b/Protocol Buffers.tmbundle/Syntaxes/Protocol Buffer.tmLanguage
@@ -502,7 +502,7 @@
 		<key>group_field</key>
 		<dict>
 			<key>begin</key>
-			<string>(repeated)?\s+?(group)\s+([A-Za-z0-9_]+)\s*=\s*(\d+)\s*{</string>
+			<string>(required|optional|repeated)?\s+?(group)\s+([A-Za-z0-9_]+)\s*=\s*(\d+)\s*{</string>
 			<key>captures</key>
 			<dict>
 				<key>1</key>
@@ -593,7 +593,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>(repeated)?\s+?(((s|u)?int|s?fixed)(32|64)|string|bytes|bool)\s+(\S+)\s*=\s*(\d+)</string>
+			<string>(required|optional|repeated)?\s+?(((s|u)?int|s?fixed)(32|64)|string|bytes|bool)\s+(\S+)\s*=\s*(\d+)</string>
 		</dict>
 		<key>reserved_field</key>
 		<dict>
@@ -737,7 +737,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>(repeated)?\s+?([A-Za-z._]*)\s+(\S+)\s*=\s*(\d+)</string>
+			<string>(required|optional|repeated)?\s+?([A-Za-z._]*)\s+(\S+)\s*=\s*(\d+)</string>
 		</dict>
 	</dict>
 	<key>scopeName</key>

--- a/Protocol Buffers.tmbundle/Syntaxes/Protocol Buffer.tmLanguage
+++ b/Protocol Buffers.tmbundle/Syntaxes/Protocol Buffer.tmLanguage
@@ -86,6 +86,10 @@
 					<key>include</key>
 					<string>#comments</string>
 				</dict>
+				<dict>
+					<key>include</key>
+					<string>#multiline_comments</string>
+				</dict>
 			</array>
 		</dict>
 		<dict>
@@ -141,6 +145,10 @@
 					<key>include</key>
 					<string>#comments</string>
 				</dict>
+				<dict>
+					<key>include</key>
+					<string>#multiline_comments</string>
+				</dict>
 			</array>
 		</dict>
 		<dict>
@@ -195,6 +203,10 @@
 				<dict>
 					<key>include</key>
 					<string>#comments</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#multiline_comments</string>
 				</dict>
 			</array>
 		</dict>
@@ -298,6 +310,10 @@
 					<key>include</key>
 					<string>#comments</string>
 				</dict>
+				<dict>
+					<key>include</key>
+					<string>#multiline_comments</string>
+				</dict>
 			</array>
 		</dict>
 		<dict>
@@ -363,6 +379,10 @@
 		<dict>
 			<key>include</key>
 			<string>#comments</string>
+		</dict>
+		<dict>
+			<key>include</key>
+			<string>#multiline_comments</string>
 		</dict>
 	</array>
 	<key>repository</key>
@@ -537,6 +557,15 @@
 			</dict>
 			<key>match</key>
 			<string>\(?([A-Za-z0-9_.]+)\)?\s*=\s*(true|false|\d+|([A-Z_]+))\b</string>
+		</dict>
+		<key>multiline_comments</key>
+		<dict>
+			<key>begin</key>
+			<string>/\*</string>
+			<key>end</key>
+			<string>\*/</string>
+			<key>name</key>
+			<string>comment.block.protobuf</string>
 		</dict>
 		<key>primitive_field</key>
 		<dict>

--- a/Protocol Buffers.tmbundle/Syntaxes/Protocol Buffer.tmLanguage
+++ b/Protocol Buffers.tmbundle/Syntaxes/Protocol Buffer.tmLanguage
@@ -126,6 +126,61 @@
 		</dict>
 		<dict>
 			<key>begin</key>
+			<string>\b(oneof)\s+([A-Za-z0-9_]+)\s*\{</string>
+			<key>beginCaptures</key>
+			<dict>
+				<key>1</key>
+				<dict>
+					<key>name</key>
+					<string>storage.type.oneof.protobuf</string>
+				</dict>
+				<key>2</key>
+				<dict>
+					<key>name</key>
+					<string>entity.name.type.oneof.protobuf</string>
+				</dict>
+			</dict>
+			<key>end</key>
+			<string>}</string>
+			<key>name</key>
+			<string>meta.oneof-declaration.protobuf</string>
+			<key>patterns</key>
+			<array>
+				<dict>
+					<key>captures</key>
+					<dict>
+						<key>1</key>
+						<dict>
+							<key>name</key>
+							<string>constant.other.user-defined.protobuf</string>
+						</dict>
+						<key>2</key>
+						<dict>
+							<key>name</key>
+							<string>constant.numeric.protobuf</string>
+						</dict>
+					</dict>
+					<key>match</key>
+					<string>\b([A-Za-z0-9_]+)\s*=\s*(\d+)\b</string>
+					<key>name</key>
+					<string>meta.individual-oneof-definition.protobuf</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>$self</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#any_field</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#comments</string>
+				</dict>
+			</array>
+		</dict>
+		<dict>
+			<key>begin</key>
 			<string>\b(service)\s+([A-Za-z0-9_]+)\s*\{</string>
 			<key>beginCaptures</key>
 			<dict>


### PR DESCRIPTION
Hey @michaeledgar,

I have been using proto3 with TextMate for a while and finally opened up the bundles editor to update the syntax highlighting to work with proto3.

~~Some of these changes are backwards-incompatible, e.g. removing `required` and `optional` keywords. If you would like me to try to get this working in both proto2 and proto3 styles, let me know.~~

Edit: I added back `required` and `optional` where I had deleted it.

/cc @pchaigno